### PR TITLE
Fix parse of regex fields containing commas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const builtInCasters = {
 };
 
 function parseValue(value, key, options = {}) {
-  if (value.includes(',')) {
+  if (!/^\/.*\/i?$/.test(value) && value.includes(',')) {
     return value
       .split(',')
       .map(arrayVal => parseValue(arrayVal, key, options));


### PR DESCRIPTION
Regex fields with commas were not being treated correctly.

Example:

I have in DB a register like this:

```
{
  ...
  "description: "This description, contains a string with comma."
}
```

My search (regex) string is:

```javascript
?description=/description, contains/
```

It does not bring anything because the parser is splitting the field value by comma like this:

```javascript
[ '/description', ' contains/' ]
```

I'm suggesting a condition for each field value that checks if it's a regex field before splitting it by comma.

Instead of:

```javascript
if (value.includes(',')) {
```

This pre-condition:

```javascript
if (!/^\/.*\/i?$/.test(value) && value.includes(',')) {
```

Hope this helps.