### PR TITLE
Fix error with null value and not equal operator.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,7 @@ const getFilter = (filter, params, options) => {
         result[key][op] = prefix !== '!';
       } else if (op === '$eq') {
         result[key] = value;
-      } else if (op === '$ne' && typeof value === 'object') {
+      } else if (op === '$ne' && typeof value === 'object' && value !== null) {
         result[key].$not = value;
       } else {
         result[key][op] = value;

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,12 @@ test('filter: $ne operator', t => {
   t.deepEqual(res.filter, { key: { $ne: 'value' } });
 });
 
+test('filter: $ne operator with null value', t => {
+  const res = aqp('key!=null');
+  t.truthy(res);
+  t.deepEqual(res.filter, { key: { $ne: null } });
+});
+
 test('filter: $not operator (with regex)', t => {
   const res = aqp('key!=/value/');
   t.truthy(res);


### PR DESCRIPTION
Before fix :
`aqp( 'value!=null') returns { filter: { value: { '$not': null } } }`

After fix:
`aqp( 'value!=null') returns { filter: { value: { '$ne': null } } }`

