### PR TITLE
Make populate param multilevel

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -349,21 +349,97 @@ test('populate', t => {
   t.deepEqual(res.population, [{ path: 'a' }, { path: 'b' }, { path: 'c' }]);
 });
 
-test('populate and projection', t => {
-  const res = aqp('populate=a,b,c&fields=j,k,l,a.x,a.y,a.z,b.x,b.y,foo.bar');
+// test('populate and projection', t => {
+//   const res = aqp('populate=a,b,c&fields=j,k,l,a.x,a.y,a.z,b.x,b.y,foo.bar');
+//   t.truthy(res);
+//   t.deepEqual(res.projection, { j: 1, k: 1, l: 1, 'foo.bar': 1 });
+//   t.deepEqual(res.population, [
+//     {
+//       path: 'a',
+//       select: { x: 1, y: 1, z: 1 },
+//     },
+//     {
+//       path: 'b',
+//       select: { x: 1, y: 1 },
+//     },
+//     {
+//       path: 'c',
+//     },
+//   ]);
+// });
+
+test('populate (nested)', t => {
+  const res = aqp('populate=a,b.b1,c.c1.c2');
   t.truthy(res);
-  t.deepEqual(res.projection, { j: 1, k: 1, l: 1, 'foo.bar': 1 });
   t.deepEqual(res.population, [
     {
       path: 'a',
-      select: { x: 1, y: 1, z: 1 },
+    },
+    {
+      path: 'b',
+      populate: {
+        path: 'b1',
+      },
+    },
+    {
+      path: 'c',
+      populate: {
+        path: 'c1',
+        populate: {
+          path: 'c2',
+        },
+      },
+    },
+  ]);
+});
+
+test('populate (nested, no duplicated)', t => {
+  const res = aqp('populate=a,a.a1,a.a1.a2');
+  t.truthy(res);
+  console.log(res.population);
+  t.deepEqual(res.population, [
+    {
+      path: 'a',
+      populate: {
+        path: 'a1',
+        populate: {
+          path: 'a2',
+        },
+      },
+    },
+  ]);
+});
+
+test('populate (nested) and projection', t => {
+  const res = aqp(
+    'populate=a,b.b1,c.c1.c2&fields=j,k,foo.bar,a.x,b.x,b.y,b.b1.x,c.x,c.c1.x,c.c1.c2.x,c.c1.c2.y'
+  );
+  t.truthy(res);
+  t.deepEqual(res.projection, { j: 1, k: 1, 'foo.bar': 1 });
+  t.deepEqual(res.population, [
+    {
+      path: 'a',
+      select: { x: 1 },
     },
     {
       path: 'b',
       select: { x: 1, y: 1 },
+      populate: {
+        path: 'b1',
+        select: { x: 1 },
+      },
     },
     {
       path: 'c',
+      select: { x: 1 },
+      populate: {
+        path: 'c1',
+        select: { x: 1 },
+        populate: {
+          path: 'c2',
+          select: { x: 1, y: 1 },
+        },
+      },
     },
   ]);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -349,25 +349,6 @@ test('populate', t => {
   t.deepEqual(res.population, [{ path: 'a' }, { path: 'b' }, { path: 'c' }]);
 });
 
-// test('populate and projection', t => {
-//   const res = aqp('populate=a,b,c&fields=j,k,l,a.x,a.y,a.z,b.x,b.y,foo.bar');
-//   t.truthy(res);
-//   t.deepEqual(res.projection, { j: 1, k: 1, l: 1, 'foo.bar': 1 });
-//   t.deepEqual(res.population, [
-//     {
-//       path: 'a',
-//       select: { x: 1, y: 1, z: 1 },
-//     },
-//     {
-//       path: 'b',
-//       select: { x: 1, y: 1 },
-//     },
-//     {
-//       path: 'c',
-//     },
-//   ]);
-// });
-
 test('populate (nested)', t => {
   const res = aqp('populate=a,b.b1,c.c1.c2');
   t.truthy(res);
@@ -396,7 +377,6 @@ test('populate (nested)', t => {
 test('populate (nested, no duplicated)', t => {
   const res = aqp('populate=a,a.a1,a.a1.a2');
   t.truthy(res);
-  console.log(res.population);
   t.deepEqual(res.population, [
     {
       path: 'a',


### PR DESCRIPTION
Hello.
The populate params didn't behave as expected. Multiple levels should be handled in order to get relations in relations populated.

Here is a PR to help :)

```
?populate=level.level1.level2&fields=level.level1.name,level.level1.level2.age
````

```javascript
population: {
    path: 'level',
    populate: {
        path: 'level1',
        select: 'name'
        populate: {
            path: 'level2',
            select: 'age'
        },
    },
}
```