### PR TITLE
fix(types): Fix types, add population and enhance query type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,14 +1,24 @@
 declare module 'api-query-params' {
+  type PopulateOptions = {
+    path: string;
+    select?: any;
+  }
+
+  type Query = {
+    [key: string]: undefined | string | string[] | Query | Query[]
+  }
+
   export type AqpQuery = {
     filter: Record<string, any>;
     skip: number;
     limit: number;
     sort: Record<string, number>;
     projection: Record<string, number>;
+    population: PopulateOptions[];
   };
 
   function aqp(
-    query: string | Record<string, string>,
+    query: string | Query,
     opt?: {
       skipKey?: string;
       limitKey?: string;


### PR DESCRIPTION
Adds the missing property `population` to the return type and extends the type of the query to allow for example the passing of an express query string.
See issue #130 