### PR TITLE
corrected javascript export so that types work properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -306,4 +306,4 @@ const aqp = (query = '', options = {}) => {
   return result;
 };
 
-module.exports = aqp;
+module.exports.default = aqp;


### PR DESCRIPTION
Current version errors when attempting to call the aqp function if imported with typescript. This fix allows for types to work properly on ts files, without breaking current use (i.e. can still be used as a default import _(import aqp from api-query-params)_