### PR TITLE
fix: use $ne instead of $not for object values from custom casters (fix #149)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -245,7 +245,7 @@ const getFilter = (filter, params, options) => {
         result[key][op] = prefix !== '!';
       } else if (op === '$eq' && Object.entries(result[key]).length === 0) {
         result[key] = value;
-      } else if (op === '$ne' && typeof value === 'object' && value !== null) {
+      } else if (op === '$ne' && value instanceof RegExp) {
         result[key].$not = value;
       } else {
         result[key][op] = value;

--- a/test/index.js
+++ b/test/index.js
@@ -539,3 +539,25 @@ test('filter: file path with slashes as string (fix #151)', (t) => {
   const res = aqp({ file: 'path/to/my/file_123.tld' });
   t.deepEqual(res.filter, { file: 'path/to/my/file_123.tld' });
 });
+
+test('filter: $ne operator with custom caster returning object (fix #149)', (t) => {
+  // Simulates ObjectId or similar object-returning caster
+  class ObjectId {
+    constructor(value) {
+      this.value = value;
+    }
+  }
+  const res = aqp('_id!=64514704b973cc48c724d563', {
+    casters: {
+      mongoId: (val) => new ObjectId(val),
+    },
+    castParams: {
+      _id: 'mongoId',
+    },
+  });
+  t.truthy(res);
+  t.truthy(res.filter._id.$ne);
+  t.falsy(res.filter._id.$not);
+  t.true(res.filter._id.$ne instanceof ObjectId);
+  t.is(res.filter._id.$ne.value, '64514704b973cc48c724d563');
+});


### PR DESCRIPTION
The != operator was incorrectly converting object values (like ObjectId from
custom casters) to $not instead of $ne. This fix changes the condition to only
use $not for RegExp instances, which aligns with MongoDB documentation where
$not is primarily used with regex patterns.