### PR TITLE
feat: add populationMaxDepth option to limit nested population depth (fix #141)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,10 +159,11 @@ const getProjection = (projection) => {
   return fields;
 };
 
-const getPopulation = (population) => {
+const getPopulation = (population, params, options) => {
   const cache = {};
+  const maxDepth = options.populationMaxDepth;
 
-  function iterateLevels(levels, prevLevels = []) {
+  function iterateLevels(levels, prevLevels = [], depth = 1) {
     let populate;
     let path;
     const topLevel = levels.shift();
@@ -176,8 +177,9 @@ const getPopulation = (population) => {
     }
     cache[cacheKey] = path;
 
-    if (levels.length) {
-      populate = iterateLevels(levels, prevLevels);
+    // Only continue nesting if we haven't reached maxDepth (when set)
+    if (levels.length && (maxDepth === undefined || depth < maxDepth)) {
+      populate = iterateLevels(levels, prevLevels, depth + 1);
       if (populate) {
         path.populate = populate;
       }

--- a/test/index.js
+++ b/test/index.js
@@ -561,3 +561,57 @@ test('filter: $ne operator with custom caster returning object (fix #149)', (t) 
   t.true(res.filter._id.$ne instanceof ObjectId);
   t.is(res.filter._id.$ne.value, '64514704b973cc48c724d563');
 });
+
+test('populate: limit depth with populationMaxDepth=1 (fix #141)', (t) => {
+  const res = aqp('populate=by.by.by.by', { populationMaxDepth: 1 });
+  t.truthy(res);
+  t.deepEqual(res.population, [{ path: 'by' }]);
+});
+
+test('populate: limit depth with populationMaxDepth=2 (fix #141)', (t) => {
+  const res = aqp('populate=a.b.c.d', { populationMaxDepth: 2 });
+  t.truthy(res);
+  t.deepEqual(res.population, [
+    {
+      path: 'a',
+      populate: {
+        path: 'b',
+      },
+    },
+  ]);
+});
+
+test('populate: populationMaxDepth with multiple paths (fix #141)', (t) => {
+  const res = aqp('populate=a.a1.a2,b.b1', { populationMaxDepth: 2 });
+  t.truthy(res);
+  t.deepEqual(res.population, [
+    {
+      path: 'a',
+      populate: {
+        path: 'a1',
+      },
+    },
+    {
+      path: 'b',
+      populate: {
+        path: 'b1',
+      },
+    },
+  ]);
+});
+
+test('populate: no depth limit when populationMaxDepth is not set (fix #141)', (t) => {
+  const res = aqp('populate=a.b.c');
+  t.truthy(res);
+  t.deepEqual(res.population, [
+    {
+      path: 'a',
+      populate: {
+        path: 'b',
+        populate: {
+          path: 'c',
+        },
+      },
+    },
+  ]);
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -26,6 +26,7 @@ declare module 'api-query-params' {
       sortKey?: string;
       filterKey?: string;
       populationKey?: string;
+      populationMaxDepth?: number;
 
       blacklist?: string[];
       whitelist?: string[];


### PR DESCRIPTION
Adds a new `populationMaxDepth` option that restricts how deep nested
population can go. This allows API consumers to prevent clients from
requesting arbitrarily deep nested data via populate query parameters.

Example: `aqp('populate=by.by.by.by', { populationMaxDepth: 1 })`
will only return `[{ path: 'by' }]` instead of 4 levels of nesting.